### PR TITLE
Replace dependency on pyb with more portable machine.

### DIFF
--- a/micropyGPS.py
+++ b/micropyGPS.py
@@ -12,14 +12,13 @@
 
 from math import floor, modf
 
-# Import pyb or time for fix time handling
+# Import utime or time for fix time handling
 try:
-    # Assume running on pyboard
-    import pyb
+    # Assume running on MicroPython
+    import utime
 except ImportError:
     # Otherwise default to time module for non-embedded implementations
-    # Note that this forces the resolution of the fix time 1 second instead
-    # of milliseconds as on the pyboard
+    # Should still support millisecond resolution.
     import time
 
 
@@ -629,7 +628,7 @@ class MicropyGPS(object):
         """Updates a high resolution counter with current time when fix is updated. Currently only triggered from
         GGA, GSA and RMC sentences"""
         try:
-            self.fix_time = pyb.millis()
+            self.fix_time = utime.ticks_ms()
         except NameError:
             self.fix_time = time.time()
 
@@ -663,11 +662,12 @@ class MicropyGPS(object):
         if self.fix_time == 0:
             return -1
 
-        # Try calculating fix time assuming using millis on a pyboard; default to seconds if not
+        # Try calculating fix time using utime; if not running MicroPython
+        # time.time() returns a floating point value in secs
         try:
-            current = pyb.elapsed_millis(self.fix_time)
+            current = utime.ticks_diff(utime.ticks_ms(), self.fix_time)
         except NameError:
-            current = time.time() - self.fix_time
+            current = (time.time() - self.fix_time) * 1000  # ms
 
         return current
 

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 """
 tests.py
 Tests for micropyGPS module


### PR DESCRIPTION
This pathch should enable it to run on generic MicroPython targets. Also tested on CPython 3.4.