### PR TITLE
Update micropyGPS.py

### DIFF
--- a/micropyGPS.py
+++ b/micropyGPS.py
@@ -264,7 +264,6 @@ class MicropyGPS(object):
             self._longitude = (0, 0.0, 'W')
             self.speed = (0.0, 0.0, 0.0)
             self.course = 0.0
-            self.date = (0, 0, 0)
             self.valid = False
 
         return True


### PR DESCRIPTION
removed clearing of date to make like timestamp, see the issue I filed regarding the date not coming back correctly in the case of GPS units with an RTC.