### PR TITLE
Don't clear date in RMC strings w/o a fix

### DIFF
--- a/micropyGPS.py
+++ b/micropyGPS.py
@@ -264,7 +264,6 @@ class MicropyGPS(object):
             self._longitude = [0, 0.0, 'W']
             self.speed = [0.0, 0.0, 0.0]
             self.course = 0.0
-            self.date = [0, 0, 0]
             self.valid = False
 
         return True


### PR DESCRIPTION
So that RTC enabled GPS units can send the date and time both back.